### PR TITLE
Update installation method for SCAN

### DIFF
--- a/tutorials/.docker/Dockerfile
+++ b/tutorials/.docker/Dockerfile
@@ -63,8 +63,8 @@ RUN pip3 install --break-system-packages /AS2FM
 
 # (SCAN)
 RUN rustup default stable
-RUN cargo install --git https://github.com/convince-project/scan
-
+RUN cargo install smc_scan --version 0.1.0 --locked
+RUN echo "PATH=$PATH:~/.cargo/bin" >> ~/.bashrc
 
 # Install REFINE-PLAN
 RUN git clone -b overarching_demo https://github.com/convince-project/refine-plan.git src/refine-plan


### PR DESCRIPTION
- Install SCAN from crates.io
- Add scan bin to PATH (necessary because of a bug in an old version of rustup)

SCAN installation was actually broken due to a missing dir in PATH (should be set by rustup but the old version used by Ubuntu has a bug or something). Moreover, I just published SCAN on the crates.io repository, so it can now be installed from there, also specifying a version. This will make the installation process more robust.

This PR addresses both issues.